### PR TITLE
Add text key addition attribute to transaction model

### DIFF
--- a/figo.gemspec
+++ b/figo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = "figo"
-  s.version       = "2.0.1"
+  s.version       = "2.0.2"
   s.authors       = ["figo GmbH", "Lukasz Ozimek", "Robert Kusmirek"]
   s.email         = ['devs@figo.io', "lukasz.ozimek@netguru.com", "robert.kusmirek@netguru.com"]
   s.homepage      = "https://github.com/figo-connect/ruby-figo"

--- a/lib/model/transaction.rb
+++ b/lib/model/transaction.rb
@@ -137,6 +137,10 @@ module Figo
       # BIC
       # @return [String]
       attr_accessor :bic
+
+      # Text key addition
+      # @return [String]
+      attr_accessor :text_key_addition
     end
   end
 end


### PR DESCRIPTION
this missing attribute caused the following error:

```
NoMethodError: undefined method `text_key_addition=' for #<Figo::Model::Transaction:0x00007f8779bf9c28>
from /Users/carstenahlf/Projekte/SmartBuchhalter/web/Source/pbw/vendor/bundle/ruby/2.4.0/bundler/gems/ruby-figo-a847054041a8/lib/model/base.rb:17:in `block in from_hash'
```