### PR TITLE
Add is_jointly_managed to account model

### DIFF
--- a/figo.gemspec
+++ b/figo.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name          = "figo"
-  s.version       = "2.0.10"
+  s.version       = "2.0.11"
   s.authors       = ["figo GmbH", "Netguru"]
   s.email         = ['devs@figo.io', "lukasz.ozimek@netguru.com", "robert.kusmirek@netguru.com"]
   s.homepage      = "https://github.com/figo-connect/ruby-figo"

--- a/lib/model/account.rb
+++ b/lib/model/account.rb
@@ -91,6 +91,10 @@ module Figo
       # @return [AccountBalance]
       attr_accessor :balance
 
+      # Is account managed by multiple people
+      # @return [Boolean]
+      attr_accessor :is_jointly_managed
+
       # Request list of transactions of this account
       #
       # @param since [String, Date] this parameter can either be a transaction ID or a date


### PR DESCRIPTION
Add `is_jointly_managed` parameter to account model due to changes in Figo v3 API